### PR TITLE
#66639-hide-bottom-tab-bar-navigator

### DIFF
--- a/config/TabNavigator.js
+++ b/config/TabNavigator.js
@@ -109,6 +109,7 @@ const Tab = createBottomTabNavigator(
 			showIcon: true
 		},
 		defaultNavigationOptions: ({ navigation }) => ({
+			tabBarVisible: false,
 			tabBarOnPress: ({ navigation, defaultHandler }) => {
 				if (navigation.state.routeName === "Games") {
 					return null;


### PR DESCRIPTION
Hiding the bottom tab navigator until users can navigate to the Games tab.