### PR TITLE
Feature/66635 show new player in record match after adding player

### DIFF
--- a/components/AddNewPlayerButton.js
+++ b/components/AddNewPlayerButton.js
@@ -7,7 +7,7 @@ function AddNewPlayerButton ({ navigation, screenHistory, arrayData }) {
 	const navigationContext = navigation.state.params || {
 	};
 
-	console.log("inside new player button array data", arrayData);
+	console.log("inside new player button prop array data", arrayData);
 
 	if (!navigationContext.hasOwnProperty("screenHistory")) {
 		Object.defineProperty(navigationContext, "screenHistory", {
@@ -27,7 +27,7 @@ function AddNewPlayerButton ({ navigation, screenHistory, arrayData }) {
 					...navigationContext.screenHistory,
 					screenHistory
 				},
-				arrayData
+				matchedPlayers: arrayData
 			})}
 		>
 			<Text style={styles.text}>

--- a/components/AddNewPlayerButton.js
+++ b/components/AddNewPlayerButton.js
@@ -3,9 +3,11 @@ import { StyleSheet } from "react-native";
 import { Button, Text, Icon } from "native-base";
 import { withNavigation } from "react-navigation";
 
-function AddNewPlayerButton ({ navigation, screenHistory }) {
+function AddNewPlayerButton ({ navigation, screenHistory, arrayData }) {
 	const navigationContext = navigation.state.params || {
 	};
+
+	console.log("inside new player button array data", arrayData);
 
 	if (!navigationContext.hasOwnProperty("screenHistory")) {
 		Object.defineProperty(navigationContext, "screenHistory", {
@@ -24,7 +26,8 @@ function AddNewPlayerButton ({ navigation, screenHistory }) {
 	        screenHistory: {
 					...navigationContext.screenHistory,
 					screenHistory
-				}
+				},
+				arrayData
 			})}
 		>
 			<Text style={styles.text}>

--- a/screens/AddNewPlayerScreen.js
+++ b/screens/AddNewPlayerScreen.js
@@ -43,7 +43,7 @@ function AddNewPlayerScreen ({ navigation }) {
 				profilePhoto
 			});
 			if (addPlayer) {
-				return navigation.navigate("PlayerAdded", {
+				return navigation.push("PlayerAdded", {
 					...navigationContext.arrayData, // <--- trying to add this to the PlayerAdded screen to pass back to Record Match & repopulate list
 					id: addPlayer.id,
 					name,

--- a/screens/AddNewPlayerScreen.js
+++ b/screens/AddNewPlayerScreen.js
@@ -17,7 +17,7 @@ function AddNewPlayerScreen ({ navigation }) {
 	const navigationContext = navigation.state.params || {
 	};
 
-	console.log("add new player screen arraydata?", navigationContext.arrayData);
+	console.log("add new player screen navContext?", navigationContext);
 	const previousScreen = navigationContext.screenHistory.screenHistory;
 	const [name, setName] = useState(undefined);
 	const [email, setEmail] = useState(undefined);
@@ -43,8 +43,8 @@ function AddNewPlayerScreen ({ navigation }) {
 				profilePhoto
 			});
 			if (addPlayer) {
-				return navigation.push("PlayerAdded", {
-					...navigationContext.arrayData, // <--- trying to add this to the PlayerAdded screen to pass back to Record Match & repopulate list
+				return navigation.navigate("PlayerAdded", {
+					...navigationContext,
 					id: addPlayer.id,
 					name,
 					email,

--- a/screens/AddNewPlayerScreen.js
+++ b/screens/AddNewPlayerScreen.js
@@ -17,7 +17,6 @@ function AddNewPlayerScreen ({ navigation }) {
 	const navigationContext = navigation.state.params || {
 	};
 
-	console.log("add new player screen navContext?", navigationContext);
 	const previousScreen = navigationContext.screenHistory.screenHistory;
 	const [name, setName] = useState(undefined);
 	const [email, setEmail] = useState(undefined);

--- a/screens/AddNewPlayerScreen.js
+++ b/screens/AddNewPlayerScreen.js
@@ -16,6 +16,8 @@ const emailRegex = RegExp(/^.+\@.+\..+$/);
 function AddNewPlayerScreen ({ navigation }) {
 	const navigationContext = navigation.state.params || {
 	};
+
+	console.log("add new player screen arraydata?", navigationContext.arrayData);
 	const previousScreen = navigationContext.screenHistory.screenHistory;
 	const [name, setName] = useState(undefined);
 	const [email, setEmail] = useState(undefined);
@@ -42,6 +44,7 @@ function AddNewPlayerScreen ({ navigation }) {
 			});
 			if (addPlayer) {
 				return navigation.navigate("PlayerAdded", {
+					...navigationContext.arrayData, // <--- trying to add this to the PlayerAdded screen to pass back to Record Match & repopulate list
 					id: addPlayer.id,
 					name,
 					email,

--- a/screens/PlayerAddedScreen.js
+++ b/screens/PlayerAddedScreen.js
@@ -12,7 +12,8 @@ const defaultProfilePhoto = require("../assets/icons/Default-user.png");
 function PlayerAddedScreen ({ navigation }) {
 	const navigationContext = navigation.state.params || {
 	};
-	console.log("player added screen nav context matchedPLayers", navigationContext.matchedPlayers);
+	const matchedPlayersData = navigationContext.matchedPlayers;
+
 	return (
 		<BgImage>
 			<HeaderSm style={styles.title} headerTitle="Player Added!" />
@@ -29,8 +30,8 @@ function PlayerAddedScreen ({ navigation }) {
 				</View>
 				<ButtonPrimary
 					title="Record Match"
-					onPress={() => navigation.navigate("RecordMatch", {
-						...navigationContext
+					onPress={() => navigation.push("RecordMatch", {
+						matchedPlayers: matchedPlayersData
 					})}
 				/>
 				<View style={styles.subContainer2}>

--- a/screens/PlayerAddedScreen.js
+++ b/screens/PlayerAddedScreen.js
@@ -10,6 +10,9 @@ import AddNewPlayerButton from "../components/AddNewPlayerButton";
 const defaultProfilePhoto = require("../assets/icons/Default-user.png");
 
 function PlayerAddedScreen ({ navigation }) {
+	const navigationContext = navigation.state.params || {
+	};
+	console.log("player added screen nav context", navigationContext);
 	return (
 		<BgImage>
 			<HeaderSm style={styles.title} headerTitle="Player Added!" />

--- a/screens/PlayerAddedScreen.js
+++ b/screens/PlayerAddedScreen.js
@@ -12,7 +12,7 @@ const defaultProfilePhoto = require("../assets/icons/Default-user.png");
 function PlayerAddedScreen ({ navigation }) {
 	const navigationContext = navigation.state.params || {
 	};
-	console.log("player added screen nav context", navigationContext);
+	console.log("player added screen nav context matchedPLayers", navigationContext.matchedPlayers);
 	return (
 		<BgImage>
 			<HeaderSm style={styles.title} headerTitle="Player Added!" />
@@ -27,7 +27,12 @@ function PlayerAddedScreen ({ navigation }) {
 					<Text style={styles.name}>{navigation.getParam("name")}</Text>
 					<Text style={styles.game}>{navigation.getParam("email")}</Text>
 				</View>
-				<ButtonPrimary title="Record Match" onPress={() => navigation.navigate("RecordMatch")} />
+				<ButtonPrimary
+					title="Record Match"
+					onPress={() => navigation.navigate("RecordMatch", {
+						...navigationContext
+					})}
+				/>
 				<View style={styles.subContainer2}>
 					<AddNewPlayerButton />
 				</View>

--- a/screens/RecordMatchScreen.js
+++ b/screens/RecordMatchScreen.js
@@ -38,6 +38,8 @@ function RecordMatchScreen ({ navigation }) {
 	const [playersError, setPlayersError] = useState(undefined);
 	const [winnersError, setWinnersError] = useState(undefined);
 
+	console.log("matched players array", matchedPlayersArray);
+
 	const formValid = () => {
 		setGameSelectError(gameSelected ? false : "your game");
 		setPlayersError(matchedPlayersArray && matchedPlayersArray.length > 1 ? false : "at least 2 players");
@@ -187,7 +189,7 @@ function RecordMatchScreen ({ navigation }) {
 						</View>
 					</Form>
 					<View style={styles.button}>
-						<AddNewPlayerButton screenHistory="Record Match" />
+						<AddNewPlayerButton screenHistory="Record Match" arrayData={matchedPlayersArray} />
 					</View>
 					<View style={styles.matchedContainer}>
 						{matchedPlayersArray.length > 0 ? <GrayHeading title="Match Players" /> : null}

--- a/screens/RecordMatchScreen.js
+++ b/screens/RecordMatchScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ScrollView, StyleSheet, View, Text, TouchableOpacity } from "react-native";
 import { withNavigation } from "react-navigation";
 import { Form, Button } from "native-base";
@@ -19,7 +19,6 @@ function RecordMatchScreen ({ navigation }) {
 	const navigationContext = navigation.state.params || {
 	};
 
-	console.log("Record Match Screen======", navigationContext);
 	if (!navigationContext.hasOwnProperty("register")) {
 		Object.defineProperty(navigationContext, "register", {
 			value: {
@@ -38,8 +37,13 @@ function RecordMatchScreen ({ navigation }) {
 	const [gameSelectError, setGameSelectError] = useState(undefined);
 	const [playersError, setPlayersError] = useState(undefined);
 	const [winnersError, setWinnersError] = useState(undefined);
+	const formerMatchedPlayersArray = navigationContext.matchedPlayers;
 
-	console.log("matched players array", matchedPlayersArray);
+	useEffect(() => {
+		if (formerMatchedPlayersArray) {
+			setMatchedPlayersArray(formerMatchedPlayersArray);
+		}
+	}, []);
 
 	const formValid = () => {
 		setGameSelectError(gameSelected ? false : "your game");

--- a/screens/RecordMatchScreen.js
+++ b/screens/RecordMatchScreen.js
@@ -19,6 +19,7 @@ function RecordMatchScreen ({ navigation }) {
 	const navigationContext = navigation.state.params || {
 	};
 
+	console.log("Record Match Screen======", navigationContext);
 	if (!navigationContext.hasOwnProperty("register")) {
 		Object.defineProperty(navigationContext, "register", {
 			value: {


### PR DESCRIPTION
After adding new player, returning to Record Match now refetches fresh data with new player available for selection while also retaining/repopulating any previously matched players list on the screen so the user doesn't need to add them a second time.