### PR TITLE
add Players screen to tab navigator for Search and Games stack

### DIFF
--- a/config/TabNavigator.js
+++ b/config/TabNavigator.js
@@ -90,6 +90,12 @@ const Search = createStackNavigator({
 			header: null
 		}
 	},
+	Players: {
+		screen: PlayersScreen,
+		navigationOptions: {
+			header: null
+		}
+	},
 	Loading: {
 		screen: LoadingScreen,
 		navigationOptions: {
@@ -131,6 +137,12 @@ const Games = createStackNavigator({
 	},
 	MatchRecorded: {
 		screen: MatchRecordedScreen,
+		navigationOptions: {
+			header: null
+		}
+	},
+	Players: {
+		screen: PlayersScreen,
 		navigationOptions: {
 			header: null
 		}


### PR DESCRIPTION
Bug: Click either "Search" or "Games" in tab navigator, then record a match, then click "Back to Home" on Match Recorded screen.  The app broke because the 'Players' route wasn't defined in the Search or Games navigation stack.
Fix: added Players route to Search and Games navigation stacks.